### PR TITLE
Fix export of getHTML and parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var shorthandProperties = {
 }
 
 
-module.exports = function(url, cb, options){
+exports = module.exports = function(url, cb, options){
 	exports.getHTML(url, function(err, html){
 		if (err) return cb(err);
 		


### PR DESCRIPTION
Unable to export getHTML and parse because
local exports object was getting overwritten
by module.exports which takes precedence.

Change allows getHTML and parse methods
to be exported.