### PR TITLE
Allow parse to be exported, move cheerio instance out of parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var shorthandProperties = {
 }
 
 
-module.exports = function(url, cb, options){
+exports = module.exports = function(url, cb, options){
 	exports.getHTML(url, function(err, html){
 		if (err) return cb(err);
 		

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ var shorthandProperties = {
 exports = module.exports = function(url, cb, options){
 	exports.getHTML(url, function(err, html){
 		if (err) return cb(err);
-		
-		cb(null, exports.parse(html, options));
+		var $ = cheerio.load(html);
+		cb(null, exports.parse($, options));
 	})
 }
 
@@ -59,11 +59,8 @@ exports.getHTML = function(url, cb){
 }
 
 
-exports.parse = function(html, options){
+exports.parse = function($, options){
 	options = options || {};
-	
-	var $ = cheerio.load(html);
-	
 	
 	// Check for xml namespace
 	var namespace,


### PR DESCRIPTION
Allow parse to be exported (details: https://github.com/samholmes/node-open-graph/pull/3#issue-50369205)

Moves cheerio instance out of parse so the cheerio instance can be used outside of parse. (As per https://github.com/janober 's suggestion: https://github.com/samholmes/node-open-graph/pull/3#issuecomment-68190869