### PR TITLE
Fix error in getHTML when statusCode wasnt 200

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ exports.getHTML = function(url, cb){
 				cb(null, body);
 			}
 			else {
-				cb(new Error("Request failed with HTTP status code: "+statusCode));
+				cb(new Error("Request failed with HTTP status code: "+res.statusCode));
 			}
 		})
 }


### PR DESCRIPTION
Since `statusCode` was not defined, it errored when the request ended with a different status code then 200.