### PR TITLE
Allow cookies when using requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ exports.getHTML = function(url, cb){
 	request({
 			url: url, 
 			encoding: 'utf8',
-			gzip: true
+			gzip: true,
+			jar: true
 		},
 		function(err, res, body) {
 			if (err) return cb(err);


### PR DESCRIPTION
A lot of sites nowadays require cookies in order to load properly and display something. One example is NYTimes.com (e.g www.nytimes.com/2016/09/27/us/california-today-los-angeles-housing-costs.html?partner=rss&emc=rss)

This one actually makes a redirect mess and there are some event emitter warnings.