### PR TITLE
fix: DoS within the parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ exports.parse = function($, options){
 
 		var key, tmp,
 			ptr = meta,
-			keys = property.split(':');
+			keys = property.split(':', 4);
 
 		// we want to leave one key to assign to so we always use references
 		// as long as there's one key left, we're dealing with a sub-node and not a value


### PR DESCRIPTION
It is possible to make the running script unresponsive by chaining thousands of colons inside one Open Graph meta property.

PoC: parse http://rawgit.com/pwnsdx/ed2e1e9dad0e0effd0e5d9c64d0596c0/raw/76b634180fe8244247457c5a5207963fb72a03fa/dos-1.html